### PR TITLE
Refactor query execution to eliminate double enumeration

### DIFF
--- a/Trelnex.Core.Data/Commands/BatchCommand.cs
+++ b/Trelnex.Core.Data/Commands/BatchCommand.cs
@@ -219,9 +219,7 @@ internal class BatchCommand<TItem>(
         CancellationToken cancellationToken)
     {
         // Extract save requests from completed acquisition tasks
-        var requests = acquireTasks
-            .Select(at => at.Result)
-            .ToArray();
+        var requests = await Task.WhenAll(acquireTasks);
 
         // Execute the batch save using the configured delegate
         var saveResults = await saveBatchAsyncDelegate(

--- a/Trelnex.Core.Data/Commands/QueryAsyncDelegate.cs
+++ b/Trelnex.Core.Data/Commands/QueryAsyncDelegate.cs
@@ -5,9 +5,7 @@ namespace Trelnex.Core.Data;
 /// </summary>
 /// <typeparam name="TItem">The item type that extends BaseItem.</typeparam>
 /// <param name="queryable">The queryable to execute.</param>
-/// <param name="cancellationToken">Token to cancel the query operation.</param>
 /// <returns>An asynchronous enumerable of items from the query execution.</returns>
-internal delegate IAsyncEnumerable<TItem> QueryAsyncDelegate<TItem>(
-    IQueryable<TItem> queryable,
-    CancellationToken cancellationToken)
+internal delegate IAsyncEnumerable<IQueryResult<TItem>> QueryAsyncDelegate<TItem>(
+    IQueryable<TItem> queryable)
     where TItem : BaseItem;

--- a/Trelnex.Core.Data/DataProviders/DbDataProvider/DbDataProvider.cs
+++ b/Trelnex.Core.Data/DataProviders/DbDataProvider/DbDataProvider.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Transactions;
 using FluentValidation;
 using LinqToDB;
@@ -59,11 +60,10 @@ public abstract class DbDataProvider<TItem>(
     }
 
     /// <inheritdoc/>
-#pragma warning disable CS1998, CS8425
     [TraceMethod]
-    protected override async IAsyncEnumerable<TItem> ExecuteQueryableAsync(
+    protected override async IAsyncEnumerable<IQueryResult<TItem>> ExecuteQueryableAsync(
         IQueryable<TItem> queryable,
-        CancellationToken cancellationToken = default)
+        [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         // Create database connection
         using var dataConnection = new DataConnection(_dataOptions);
@@ -79,10 +79,11 @@ public abstract class DbDataProvider<TItem>(
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            yield return item;
+            var queryResult = ConvertToQueryResult(item);
+
+            yield return queryResult;
         }
     }
-#pragma warning restore CS1998, CS8425
 
     /// <inheritdoc/>
     [TraceMethod]


### PR DESCRIPTION
Changes the QueryAsyncDelegate to return IQueryResult<TItem> directly instead of TItem, moving the conversion responsibility to data provider implementations. This eliminates an intermediate async iterator layer, improving performance and simplifying the cancellation token flow through [EnumeratorCancellation].

Key changes:
  - QueryAsyncDelegate now returns IAsyncEnumerable<IQueryResult<TItem>>
  - Data providers implement ExecuteQueryableAsync with [EnumeratorCancellation]
  - Removed intermediate QueryAsync method from QueryCommand
  - Added ConvertToQueryResult helper method to DataProvider base class
  - Fixed BatchCommand to use await Task.WhenAll() instead of blocking .Result